### PR TITLE
Added AA Rounded Corners to Titlebars

### DIFF
--- a/other/picom/picom.conf
+++ b/other/picom/picom.conf
@@ -205,11 +205,11 @@ blur-background-exclude = [
 ];
 
 ### Window types ###
-#wintypes: {
-#	normal = {
-#		full-shadow = true;
-#	};
-#}
+wintypes: {
+	normal = {
+		full-shadow = true;
+	};
+}
 
 ### Other settings ###
 experimental-backends  = true;  # More modern but less stable code


### PR DESCRIPTION
This also adds fake borders only in floating, as X11 borders do not work well with
titlebars. The AwesomeWM config should behave exactly the same as
before. There might be some issues with shadows, which we can discuss later (there is an option to fix this).